### PR TITLE
Change Installation Instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ warned.**
 
 ## Installation
 
-Nimbox can be installed through [Nimble][nimble], Nim's package manager:
+This version of Nimbox should be downloaded manually and then installed
+through [Nimble][nimble], Nim's package manager:
 
 ```shell
-nimble install nimbox
+git clone https://github.com/dom96/nimbox.git
+cd nimbox
+nimble install .
 ```
 
 [rb]: https://github.com/gchp/rustbox


### PR DESCRIPTION
The current instructions use the nimble.directory install. This
currently downloads from https://notabug.org/vktec/nimbox. The code
there is out of date, containing a type error bug which has been
fixed in this repository. Until the nimble.directory is updated to
point to this repository, this updates the readme to reflect the
manual download and install method rather than the automatic.

closes #1