### PR TITLE
Add 256 Color Support

### DIFF
--- a/examples/colors256.nim
+++ b/examples/colors256.nim
@@ -1,0 +1,19 @@
+import nimbox
+import os
+
+when isMainModule:
+  var nb = newNimbox()
+  defer: nb.shutdown()
+
+  nb.outputMode = out256
+
+#Colors are defined using xTerm numbers.
+  nb.print(0, 0, "Hello, world!", 12, 0, styNone)
+  nb.print(0, 1, "Hello, world!", 52, 51, styBold)
+
+  for i in 0..255:
+    var x = ((i mod 16) * 3) - 2
+    nb.print(x, i div 16 + 2, $i, i, 0, styNone)
+  nb.present()
+  sleep(1000)
+

--- a/nimbox.nim
+++ b/nimbox.nim
@@ -168,6 +168,24 @@ proc print*[T](_: Nimbox, x, y: int, text: string,
     tbChangeCell(cast[cint](x + i), yInt, c.uint32, fgInt, bgInt)
     i.inc()
 
+proc print*[T](_: Nimbox, x, y: int, text: string,
+               fg: int, bg: int, style: T = styNone) =
+  var styleInt: int
+  when style is Style:
+    styleInt = ord(style)
+  elif style is int:
+    styleInt = style
+
+  var
+    fgInt = cast[uint16](fg or styleInt)
+    bgInt = cast[uint16](bg)
+    yInt = cast[cint](y)
+
+  var i = 0
+  for c in runes(text):
+    tbChangeCell(cast[cint](x + i), yInt, c.uint32, fgInt, bgInt)
+    i.inc()
+
 proc print*(nb: Nimbox, x, y: int, text: string,
             fg: Color = clrDefault, bg: Color = clrDefault) =
   print(nb, x, y, text, fg, bg, styNone)

--- a/nimbox.nim
+++ b/nimbox.nim
@@ -5,6 +5,8 @@ import unicode
 type
   Nimbox* = object of RootObj
 
+  Colors256* = range[0..255]
+
   Modifier* {.pure.} = enum
     Ctrl
     Alt
@@ -169,7 +171,7 @@ proc print*[T](_: Nimbox, x, y: int, text: string,
     i.inc()
 
 proc print*[T](_: Nimbox, x, y: int, text: string,
-               fg: int, bg: int, style: T = styNone) =
+               fg: Colors256, bg: Colors256, style: T = styNone) =
   var styleInt: int
   when style is Style:
     styleInt = ord(style)


### PR DESCRIPTION
This commit addresses issue #2. It adds 256 color support very naively.
It does not check for terminal support of 256 colors. It does not check
that the int provided is in the range 0..255. It does not have any error
checking or handling of any sort.

Fixes: #2