### PR TITLE
Replace wrap all code in each example inside a proc

### DIFF
--- a/examples/colors.nim
+++ b/examples/colors.nim
@@ -1,7 +1,7 @@
 import nimbox
 import os
 
-when isMainModule:
+proc main() =
   var nb = newNimbox()
   defer: nb.shutdown()
 
@@ -13,3 +13,6 @@ when isMainModule:
   nb.present()
   sleep(1000)
 
+
+when isMainModule:
+  main()

--- a/examples/colors256.nim
+++ b/examples/colors256.nim
@@ -1,7 +1,7 @@
 import nimbox
 import os
 
-when isMainModule:
+proc main() =
   var nb = newNimbox()
   defer: nb.shutdown()
 
@@ -17,3 +17,6 @@ when isMainModule:
   nb.present()
   sleep(1000)
 
+
+when isMainModule:
+  main()

--- a/examples/cursor.nim
+++ b/examples/cursor.nim
@@ -1,7 +1,7 @@
 import nimbox
 import os
 
-when isMainModule:
+proc main() =
   var nb = newNimbox()
   defer: nb.shutdown()
 
@@ -13,3 +13,6 @@ when isMainModule:
     # nb.present()
     # sleep(1000)
 
+
+when isMainModule:
+  main()

--- a/examples/dimensions.nim
+++ b/examples/dimensions.nim
@@ -1,7 +1,7 @@
 import nimbox
 import os
 
-when isMainModule:
+proc main() =
   var nb = newNimbox()
   defer: nb.shutdown()
 
@@ -9,3 +9,6 @@ when isMainModule:
   nb.present()
   sleep(1000)
 
+
+when isMainModule:
+  main()

--- a/examples/events.nim
+++ b/examples/events.nim
@@ -1,7 +1,7 @@
 import nimbox
 import os
 
-when isMainModule:
+proc main() =
   var nb = newNimbox()
   defer: nb.shutdown()
 
@@ -20,3 +20,5 @@ when isMainModule:
         ch = evt.ch
       else: discard
 
+when isMainModule:
+  main()

--- a/examples/hello_world.nim
+++ b/examples/hello_world.nim
@@ -1,7 +1,7 @@
 import nimbox
 import os
 
-when isMainModule:
+proc main() =
   var nb = newNimbox()
   defer: nb.shutdown()
 
@@ -9,3 +9,5 @@ when isMainModule:
   nb.present()
   sleep(1000)
 
+when isMainModule:
+  main()


### PR DESCRIPTION
This is done to address issue #9. Based on the language manual, the
defer keyword is not supported at the top level. But defer is used to
ensure that nimbox cleans up after itself when it is finished.
Therefore we need to wrap the call to defer inside a proc.